### PR TITLE
Added excluded InvoicesApi to typings and connectwise.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 typings
 test
 release
+.idea

--- a/connectwise.d.ts
+++ b/connectwise.d.ts
@@ -14268,6 +14268,7 @@ export class Connectwise {
 	AccountingBatchesApi: fin.AccountingBatchesApi;
 	AgreementBoardDefaultsApi: fin.AgreementBoardDefaultsApi;
 	InvoicePaymentsApi: fin.InvoicePaymentsApi;
+	InvoicesApi: fin.InvoicesApi;
 	AccountingBatchTransactionsApi: fin.AccountingBatchTransactionsApi;
 	AccountingUnpostedExpensesApi: fin.AccountingUnpostedExpensesApi;
 	AccountingUnpostedInvoicesApi: fin.AccountingUnpostedinvoicesApi;

--- a/src/connectwise.ts
+++ b/src/connectwise.ts
@@ -38,6 +38,7 @@ export class Connectwise {
 	public AccountingBatchesApi: fin.AccountingBatchesApi;
 	public AgreementBoardDefaultsApi: fin.AgreementBoardDefaultsApi;
 	public InvoicePaymentsApi: fin.InvoicePaymentsApi;
+	public InvoicesApi: fin.InvoicesApi;
 	public AccountingBatchTransactionsApi: fin.AccountingBatchTransactionsApi;
 	public AccountingUnpostedExpensesApi: fin.AccountingUnpostedExpensesApi;
 	public AccountingUnpostedInvoicesApi: fin.AccountingUnpostedinvoicesApi;


### PR DESCRIPTION
The InvoicesApi was excluded for some reason. All the code is there, it just wasn't exported. I added it back as it was needed in a project I'm working on. 

I noticed the tests directory was `.gitingore`d. If you have tests for this code, please publish so I can write one for the InvoicesApi.

Thanks!
Andreas